### PR TITLE
Бэкпорт хуков из 1.24.1

### DIFF
--- a/lib/resque/integration.rb
+++ b/lib/resque/integration.rb
@@ -12,11 +12,15 @@ require 'resque-ensure-connected'
 
 require 'active_support/concern'
 
+require 'resque/integration/hooks'
 require 'resque/integration/engine'
 
 require 'active_support/core_ext/module/attribute_accessors'
 
 module Resque
+  include Integration::Hooks
+  extend Integration::Hooks
+
   # Resque.config is available now
   mattr_accessor :config
 

--- a/lib/resque/integration/hooks.rb
+++ b/lib/resque/integration/hooks.rb
@@ -1,0 +1,72 @@
+# coding: utf-8
+
+module Resque
+  module Integration
+    # Backport of resque-1.24.x hooks
+    # @see https://github.com/resque/resque/pull/680/files
+    module Hooks
+      # We do not want to patch Worker, so we declare callable Array
+      class CallableArray < Array
+        def call(*args)
+          each { |hook| hook.call(*args) }
+        end
+      end
+      # Call with a block to register a hook.
+      # Call with no arguments to return all registered hooks.
+      def before_first_fork(&block)
+        block ? register_hook(:before_first_fork, block) : hooks(:before_first_fork)
+      end
+
+      # Register a before_first_fork proc.
+      def before_first_fork=(block)
+        register_hook(:before_first_fork, block)
+      end
+
+      # Call with a block to register a hook.
+      # Call with no arguments to return all registered hooks.
+      def before_fork(&block)
+        block ? register_hook(:before_fork, block) : hooks(:before_fork)
+      end
+
+      # Register a before_fork proc.
+      def before_fork=(block)
+        register_hook(:before_fork, block)
+      end
+
+      # Call with a block to register a hook.
+      # Call with no arguments to return all registered hooks.
+      def after_fork(&block)
+        block ? register_hook(:after_fork, block) : hooks(:after_fork)
+      end
+
+      # Register an after_fork proc.
+      def after_fork=(block)
+        register_hook(:after_fork, block)
+      end
+
+      private
+
+      # Register a new proc as a hook. If the block is nil this is the
+      # equivalent of removing all hooks of the given name.
+      #
+      # `name` is the hook that the block should be registered with.
+      def register_hook(name, block)
+        return clear_hooks(name) if block.nil?
+
+        @hooks ||= {}
+        @hooks[name] ||= CallableArray.new
+        @hooks[name] << block
+      end
+
+      # Clear all hooks given a hook name.
+      def clear_hooks(name)
+        @hooks && @hooks[name] = CallableArray.new
+      end
+
+      # Retrieve all hooks of a given name.
+      def hooks(name)
+        (@hooks && @hooks[name]) || CallableArray.new
+      end
+    end # module Hooks
+  end # module Integration
+end # module Resque

--- a/lib/resque/integration/tasks/hooks.rake
+++ b/lib/resque/integration/tasks/hooks.rake
@@ -19,10 +19,10 @@ namespace :resque do
     #   Resque.after_fork { ActiveRecord::Base.connection_handler.verify_active_connections! }
     #
     # Это работает
-    Resque.before_fork { ActiveRecord::Base.connection_handler.clear_all_connections! }
+    Resque.before_first_fork { ActiveRecord::Base.connection_handler.clear_all_connections! }
 
     # Нужно также закрыть соединение к memcache
-    Resque.before_fork { Rails.cache.reset if Rails.cache.respond_to?(:reset) }
+    Resque.before_first_fork { Rails.cache.reset if Rails.cache.respond_to?(:reset) }
 
     # Support for resque-multi-job-forks
     if ENV['JOBS_PER_FORK'] || ENV['MINUTES_PER_FORK']


### PR DESCRIPTION
# Описание проблемы

В старой версии resque (на коей мы сейчас и находимся из-за невозможности обновить некоторые плагины) можно было установить только один хук на событие (события бывают `before_fork`, `after_fork` и `before_first_fork`).

Из-за этого были сотни багов, ломался гем `resque-ensure-connected`.
В 1.24 это исправили и можно на события вешать сколько угодно хуков.
