### PR TITLE
Исправление ошибки в resque-status

### DIFF
--- a/bin/resque-status
+++ b/bin/resque-status
@@ -4,7 +4,14 @@
 # Скрипт для мониторинга состояния resque
 
 require 'rubygems'
-gem 'resque-integration'
+
+%w(oj yajl-ruby json gson).each do |library|
+  begin
+    gem(library) and break
+  rescue Gem::LoadError
+    # ignore, go to next adapter
+  end
+end
 
 require 'resque'
 require 'redis'


### PR DESCRIPTION
Жил себе добрый молодец с зеркальцем всевидящим, да пришла внезапно кручина на его лихую головушку. Видел он в зеркальце чудного гостя заморского в рубинах, и писал гость заморский цифры дивные, предупреждал о тревоге грозящей, да все довольны были, но вдруг пропали вести ни с того ни сего. И отправился молодец искать доброго гостя, напал на след его, а тот ни жив ни мертв, письмена неведомы от себя оставляет:

```
blizko@k960-bz-yml /home/blizko/current $ resque-status
[WARNING] MultiJson is using the default adapter (ok_json). We recommend loading a different JSON library to improve performance.
/home/blizko/.gem/ruby/1.9/gems/resque-1.23.0/lib/resque/helpers.rb:6:in `<top (required)>': Please install the yajl-ruby or json gem (RuntimeError)
```

помутнело зеркальце, обуяла тоска молодца. Да и дальше сгущаются тучи, идут вести дурные с чужого берега, брат-близнец гостя заморского слег с кручиной неводомой - http://d.pr/i/6jMU

Славный лекарь, земель благодатных, слухи ходят гремучие что возвращаешь ты к жизни прежней, отмороженных да буйных. Чай не гневайся да войди в положение, излечи ты братьев от напасти неведомой.

(c) Лесовский. http://jira.dev.apress.ru/browse/BPC-3118
