### PR TITLE
fix: undefined method `silence_warnings'` for main:Object

### DIFF
--- a/lib/resque/integration/unique.rb
+++ b/lib/resque/integration/unique.rb
@@ -5,7 +5,7 @@ require 'digest/sha1'
 require 'active_support/core_ext/module/aliasing'
 
 require 'resque/plugins/lock'
-silence_warnings { require 'resque/plugins/progress' } # suppress Resque::Helpers warn
+require 'resque/plugins/progress'
 
 module Resque
   module Integration


### PR DESCRIPTION
this errors raises in gem resque-reports, if use activesupport
version 3.1.12

But silence_warnings not suspend warnings about `Resque::Helpers` because
resque reports not use warnigns, and this warn still present if use silence_warnings
