### PR TITLE
chore(resque helpers): overriding resque helpers to delete deprecated warning messages

### DIFF
--- a/lib/resque/integration.rb
+++ b/lib/resque/integration.rb
@@ -3,6 +3,10 @@ require 'resque/integration/version'
 
 require 'resque'
 
+require 'active_support/core_ext/kernel/reporting'
+
+silence_warnings { require 'resque/plugins/meta' }
+
 require 'rails/railtie'
 require 'rake'
 

--- a/lib/resque/integration/application.rb
+++ b/lib/resque/integration/application.rb
@@ -1,6 +1,5 @@
 # coding: utf-8
 require 'resque/integration'
-require 'resque/plugins/meta'
 require 'sinatra/base'
 require 'multi_json'
 


### PR DESCRIPTION
Убрал сообщение при инициализации проекта

**Resque::Helpers will be gone with no replacement in Resque 2.0.0.**

https://github.com/resque/resque/blob/1-x-stable/lib/resque/helpers.rb#L15
https://github.com/resque/resque/blob/1-x-stable/lib/resque/helpers.rb#L19

Сообщение начало появляться из-за новой версии gem'а resque-meta 2.0.1
Добавилась строчка.
https://github.com/lmarlow/resque-meta/blob/master/lib/resque/plugins/meta/metadata.rb#L7
