### PR TITLE
feature: independent meta for ordered jobs

### DIFF
--- a/resque-integration.gemspec
+++ b/resque-integration.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 2.14'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'mock_redis'
+  gem.add_development_dependency 'pry-debugger'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # coding: utf-8
 require 'bundler/setup'
+require 'pry-debugger'
 require 'rspec'
 require 'resque'
 require 'simplecov'


### PR DESCRIPTION
https://jira.railsc.ru/browse/PC4-15507

смысл реквеста такой: 
уникальные джобы имеют общий мета объект
данный код делает еще один мета объект для каждого набора аргументов в очереди
это акутально для ети, т.к. туда пишутся ошибки после каждой операции
