### PR TITLE
fix: исправление зависимости resque-retry

### DIFF
--- a/resque-integration.gemspec
+++ b/resque-integration.gemspec
@@ -26,8 +26,10 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'resque-progress', '~> 1.0.1'
   gem.add_runtime_dependency 'resque-multi-job-forks', '~> 0.4.2'
   gem.add_runtime_dependency 'resque-failed-job-mailer', '~> 0.0.3'
+  # https://github.com/abak-press/resque-integration/issues/71#issuecomment-147942096
   gem.add_runtime_dependency 'resque-scheduler', '~> 3.0'
-  gem.add_runtime_dependency 'resque-retry', '~> 1.3'
+  # фиксируем патч версию, т.к. 1.4 зависит от resque-sheduler 4
+  gem.add_runtime_dependency 'resque-retry', '~> 1.3.0'
   gem.add_runtime_dependency 'god', '~> 0.13.4'
 
   gem.add_runtime_dependency 'multi_json'


### PR DESCRIPTION
версия resque-scheduler зафиксирована на мажорную 3(https://github.com/abak-press/resque-integration/issues/71#issuecomment-147942096),
а resque-retry начиная с 1.4 требует 4

https://jira.railsc.ru/browse/SERVICES-594
https://jira.railsc.ru/browse/SERVICES-344
