### PR TITLE
fix: allow change name for worker in god

### DIFF
--- a/lib/resque/integration/god.erb
+++ b/lib/resque/integration/god.erb
@@ -9,7 +9,7 @@ God.terminate_timeout = <%= terminate_timeout.to_i %>
   <% worker.count.times do |i| %>
     God.watch do |w|
       w.dir = rails_root
-      w.name = 'resque-<%= worker.queue %>-<%= i %>'
+      w.name = 'resque-<%= worker.name || worker.queue %>-<%= i %>'
       w.group = 'resque'
       w.interval = 30.seconds
       w.env = <%= Resque.config.env.merge(worker.env).merge(:RAILS_ENV => ::Rails.env, :BUNDLE_GEMFILE => "#{root}/Gemfile").stringify_keys! %>


### PR DESCRIPTION
https://jira.railsc.ru/browse/PC4-15870

Проблема:

```
F [2015-10-26 13:50:25] FATAL: Unhandled exception in driver loop - (Errno::ENAMETOOLONG): File name too long
```

Возникает, если конфиг воркера содержит слишком много очередей в имени.
