### PR TITLE
feat: resque-status: oldest job work time

### DIFF
--- a/bin/resque-status
+++ b/bin/resque-status
@@ -4,6 +4,7 @@ require 'optparse'
 require 'redis'
 require 'resque'
 require 'active_support/core_ext/hash/slice'
+require 'active_support/time'
 
 options = {}
 
@@ -47,6 +48,12 @@ key = options.fetch(:key, :pending).to_sym
 
 if info.key?(key)
   puts info[key]
+elsif key == :oldest
+  # oldest job work time in seconds
+  workers = Resque.workers
+  jobs = workers.map(&:job)
+  worker_jobs = workers.zip(jobs).reject { |w, j| w.idle? || j['queue'].nil? }
+  puts worker_jobs.map { |_, job| (Time.now.utc - DateTime.strptime(job['run_at'] ,'%Y-%m-%dT%H:%M:%S').utc).to_i }.max
 else
   $stderr.puts "Unknown key. Should be one of the [#{info.keys.join(', ')}]"
 end


### PR DESCRIPTION
Для организации мониторинга долго-выполняющихся джобов.
Возвращает время работы в секундах, самого старого из работающих джобов.
