### PR TITLE
fix: false results in overall queue info

### DIFF
--- a/lib/resque/integration/queues_info.rb
+++ b/lib/resque/integration/queues_info.rb
@@ -1,95 +1,42 @@
 module Resque
   module Integration
     class QueuesInfo
+      autoload :Age, "resque/integration/queues_info/age"
+      autoload :Size, "resque/integration/queues_info/size"
+      autoload :Config, "resque/integration/queues_info/config"
+
       def initialize(options)
-        config = load_config(options.fetch(:config))
-        @defaults = config['defaults']
-        @queues = expand_config(config['queues'])
+        @config = Config.new(options.fetch(:config))
+        @size = Size.new(@config)
+        @age = Age.new(@config)
       end
 
       def age_for_queue(queue)
-        job, max_time = find_longest_job { |job| job['queue'] == queue }
-
-        return 0 if job.nil? || max_time.nil?
-
-        max_time
+        @age.time(queue)
       end
 
       def age_overall
-        job, max_time = find_longest_job { |job| !job['queue'].nil? }
-
-        return 0 if job.nil? || max_time.nil?
-
-        max_time >= threshold_age(job['queue']) ? max_time : 0
+        @age.overall
       end
 
-      def size_for_queue(queue = nil)
-        Resque.size(queue) || 0
+      def size_for_queue(queue)
+        @size.size(queue)
       end
 
       def size_overall
-        queue, size = Resque.queues.map do |queue|
-          [queue, Resque.size(queue).to_i]
-        end.max_by(&:last)
-
-        size >= threshold_size(queue) ? size : 0
+        @size.overall
       end
 
       def threshold_size(queue)
-        (@queues[queue] || @defaults)['max_size']
+        @config.max_size(queue)
       end
 
       def threshold_age(queue)
-        (@queues[queue] || @defaults)['max_age']
+        @config.max_age(queue)
       end
 
       def data
-        @data ||= @queues.map do |k, v|
-          {
-            "{#QUEUE}" => k
-          }
-        end
-      end
-
-      private
-
-      def find_longest_job
-        workers = Resque.workers
-        jobs = workers.map(&:job)
-
-        working_jobs = workers.zip(jobs).select do |w, j|
-          !w.idle? && yield(j)
-        end
-
-        working_jobs.map do |_, job|
-          [job, seconds_for(job)]
-        end.max_by(&:last)
-      end
-
-      def seconds_for(job)
-        (Time.now.utc - DateTime.strptime(job['run_at'], '%Y-%m-%dT%H:%M:%S').utc).to_i
-      end
-
-      def load_config(path)
-        input = File.read(path)
-        input = ERB.new(input).result if defined?(ERB)
-        YAML.load(input)
-      end
-
-      def expand_config(config)
-        keys = config.keys.dup
-
-        keys.each do |key|
-          v = config.delete(key)
-
-          key.split(',').each do |queue|
-            queue.chomp!
-            queue.strip!
-            config[queue] = v
-          end
-        end
-
-        config
+        @config.data
       end
     end
   end

--- a/lib/resque/integration/queues_info/age.rb
+++ b/lib/resque/integration/queues_info/age.rb
@@ -1,0 +1,53 @@
+module Resque
+  module Integration
+    class QueuesInfo
+      class Age
+        def initialize(config)
+          @config = config
+        end
+
+        def time(queue)
+          from_time = Time.now.utc
+          max_secs = 0
+
+          jobs.each do |job|
+            next unless job['queue'] == queue
+            job_secs = seconds_for(job, from_time)
+            max_secs = job_secs if job_secs > max_secs
+          end
+
+          max_secs
+        end
+
+        def overall
+          from_time = Time.now.utc
+
+          max_secs = 0
+
+          jobs.each do |job|
+            next unless job['queue']
+            job_secs = seconds_for(job, from_time)
+            next if job_secs < threshold(job['queue'])
+            max_secs = job_secs if job_secs > max_secs
+          end
+
+          max_secs
+        end
+
+        def threshold(queue)
+          @config.max_age(queue)
+        end
+
+        private
+
+        def jobs
+          Resque.workers.each_with_object([]) { |worker, memo| memo << worker.job unless worker.idle? }
+        end
+
+        def seconds_for(job, from_time)
+          (from_time - DateTime.strptime(job['run_at'], '%Y-%m-%dT%H:%M:%S').utc).to_i
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/integration/queues_info/config.rb
+++ b/lib/resque/integration/queues_info/config.rb
@@ -1,0 +1,57 @@
+module Resque
+  module Integration
+    class QueuesInfo
+      class Config
+        def initialize(config_path)
+          config = load_config(config_path)
+          @defaults = config['defaults']
+          @queues = expand_config(config['queues'])
+        end
+
+        def max_age(queue)
+          threshold(queue, 'max_age')
+        end
+
+        def max_size(queue)
+          threshold(queue, 'max_size')
+        end
+
+        def data
+          @data ||= @queues.map do |k, v|
+            {
+              "{#QUEUE}" => k
+            }
+          end
+        end
+
+        private
+
+        def threshold(queue, param)
+          (@queues[queue] || @defaults)[param]
+        end
+
+        def load_config(path)
+          input = File.read(path)
+          input = ERB.new(input).result if defined?(ERB)
+          YAML.load(input)
+        end
+
+        def expand_config(config)
+          keys = config.keys.dup
+
+          keys.each do |key|
+            v = config.delete(key)
+
+            key.split(',').each do |queue|
+              queue.chomp!
+              queue.strip!
+              config[queue] = v
+            end
+          end
+
+          config
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/integration/queues_info/size.rb
+++ b/lib/resque/integration/queues_info/size.rb
@@ -1,0 +1,33 @@
+module Resque
+  module Integration
+    class QueuesInfo
+      class Size
+        def initialize(config)
+          @config = config
+        end
+
+        def size(queue)
+          Resque.size(queue) || 0
+        end
+
+        def overall
+          max = 0
+
+          Resque.queues.each do |queue|
+            size = Resque.size(queue).to_i
+            next if size < threshold(queue)
+            max = size if size > max
+          end
+
+          max
+        end
+
+        private
+
+        def threshold(queue)
+          @config.max_size(queue)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Проблема:
Если у одной очереди порог 1000 у другой 50, у очереди с порогом 1000 текущее состояние 800, а у второй 75, то размер вернется 0, тк ищем самую большую очередь, а не самую большую очередь с **_превышеным порогом**_.
