### PR TITLE
fix: job not unlock if unique definded with block and hash

### DIFF
--- a/lib/resque/integration/unique.rb
+++ b/lib/resque/integration/unique.rb
@@ -3,6 +3,7 @@
 require 'digest/sha1'
 
 require 'active_support/core_ext/module/aliasing'
+require 'active_support/core_ext/hash'
 
 require 'resque/plugins/lock'
 require 'resque/plugins/progress'
@@ -66,6 +67,8 @@ module Resque
         # LockID should be independent from MetaID
         # @api private
         def lock(meta_id, *args)
+          args = [*args[0..-2], args.last.with_indifferent_access] if args.last.is_a?(Hash)
+
           "lock:#{name}-#{Digest::SHA1.hexdigest(obj_to_string(lock_on[*args]))}"
         end
 

--- a/resque-integration.gemspec
+++ b/resque-integration.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'railties', '>= 3.0.0'
   gem.add_runtime_dependency 'activerecord', '>= 3.0.0'
   gem.add_runtime_dependency 'actionpack', '>= 3.0.0'
+  gem.add_runtime_dependency 'activesupport', '>= 3.0.0'
   gem.add_runtime_dependency 'resque-lock', '~> 1.1.0'
   gem.add_runtime_dependency 'resque-meta', '>= 2.0.0'
   gem.add_runtime_dependency 'resque-progress', '~> 1.0.1'

--- a/spec/resque/integration_spec.rb
+++ b/spec/resque/integration_spec.rb
@@ -21,40 +21,90 @@ RSpec.describe Resque::Integration do
 
   describe 'enqueue' do
     context 'when job is uniq' do
+      class DummyService
+        def self.call
+          # no-op
+        end
+      end
+
       class UniqueJob
         include Resque::Integration
 
         queue :test
         unique
+
+        def self.execute(id, params)
+          DummyService.call
+        end
       end
 
       it 'enqueues only one job' do
-        UniqueJob.enqueue(param: 'one')
+        UniqueJob.enqueue(1, param: 'one')
 
         Timecop.travel(10.hours.since) do
-          UniqueJob.enqueue(param: 'one')
+          UniqueJob.enqueue(1, param: 'one')
 
           expect(Resque.peek(:test, 0, 100).size).to eq(1)
         end
       end
 
       it 'enqueues two jobs with differ args' do
-        UniqueJob.enqueue(param: 'one')
+        UniqueJob.enqueue(1, param: 'one')
 
         Timecop.travel(10.hours.since) do
-          UniqueJob.enqueue(param: 'two')
+          UniqueJob.enqueue(1, param: 'two')
 
           expect(Resque.peek(:test, 0, 100).size).to eq(2)
         end
       end
 
       it 'enqueues two jobs after expire lock timeout' do
-        UniqueJob.enqueue(param: 'one')
+        UniqueJob.enqueue(1, param: 'one')
 
         Timecop.travel(4.days.since) do
-          UniqueJob.enqueue(param: 'one')
+          UniqueJob.enqueue(1, param: 'one')
 
           expect(Resque.peek(:test, 0, 100).size).to eq(2)
+        end
+      end
+
+      describe 'unlock' do
+        class UniqueJobWithBlock
+          include Resque::Integration
+
+          queue :test_with_block
+          unique { |id, params| [id, params[:one], params[:two]] }
+
+          def self.execute(id, params)
+            DummyService.call
+          end
+        end
+
+        around do |example|
+          inline = Resque.inline
+          Resque.inline = true
+
+          example.run
+
+          Resque.inline = inline
+        end
+
+        it 'unlocks uniq job with args and without block' do
+          expect(DummyService).to receive(:call).twice
+
+          UniqueJob.enqueue(1, one: 1, two: 2)
+          UniqueJob.enqueue(1, one: 1, two: 2)
+
+          expect(UniqueJob.locked?(1, one: 1, two: 2)).to eq(false)
+        end
+
+        it 'unlocks uniq job with args and block' do
+          expect(DummyService).to receive(:call).twice
+
+          UniqueJobWithBlock.enqueue(1, one: 1, two: 2)
+          UniqueJobWithBlock.enqueue(1, one: 1, two: 2)
+
+          expect(UniqueJobWithBlock.locked?(1, one: 1, two: 2)).to eq(false)
         end
       end
     end


### PR DESCRIPTION
Обнаружилась еще одна проблема с уникальность

Если в джобе есть параметры в виде хеша, и эти параметры явно указываются в блоке `unique` примерно так `unique { |id, params| [id, params[:one], params[:two]] }`, то джоб не убирает свой лок после выполнения.

Попробую объяснить:

1. Ставим первый джоб примерно так 
`Job.enqueue(delviery.id, one: 'default', two: 'user')`

2. При постановке проверятся уникальность
https://github.com/abak-press/resque-integration/blob/master/lib/resque/integration/unique.rb#L119
Тут внутри `args` хеш где ключи это символы
вызывается блок `unique`, где мы возвращаеи что то по ключам :one, :two, (символы)
Все хорошо

3. Джоб выполняеться
4. Срабатывает колбек `around_perform_lock` где после yeild мы в любом случае должны удалить лок, но в этом случае хеш внутри уже со строковыми ключами
https://github.com/defunkt/resque-lock/blob/master/lib/resque/plugins/lock.rb#L84

5. Снова вызывается блок из `unique` и там мы уже возвращаем неверные значения типа `[1, nil, nil]`, лок не удаляеться так как формируеться не верный ключ
6. Ставим второй джоб, он видит лок ( ._.)

Все это ломается в том случае если есть хеш параметров и мы явно хотим указать их в уникальности. Если джоб просто с уникальностю без явного указания, то все работает так как по дефолту возаращаем все агрументы https://github.com/abak-press/resque-integration/blob/master/lib/resque/integration/unique.rb#L62

Тут варианта 3 на самом деле
1. Как я тут сделал - перевод ключей в символы
2. Переводить ключи в символы в самом блоке `unique` в конкретном джобе
```
unique do |id, params|
  params.symbolize_keys!
  [id, params[:one], params[:two]]
end
```
Но тут надо помнить об этом поведении и постоянно огребать ;)
3. Использовать всегда строки в джобах

Бонус
если есть уникальные джобы с наследованием
```
class Base
   unique { ... }
end

class UseJob < Base; end;
````

В этом случае уник запоминает блок только на базовый джоб, а при выполнении реального уже возвращает все аргументы
Тут запоминает в переменную для базового класса
https://github.com/abak-press/resque-integration/blob/master/lib/resque/integration/unique.rb#L60

тут при выполнении переопределяет ее та как класс уже другой
https://github.com/abak-press/resque-integration/blob/master/lib/resque/integration/unique.rb#L62



