### PR TITLE
feat: add failed resque jobs data for zabbix

### DIFF
--- a/app/controllers/resque/queues/status_controller.rb
+++ b/app/controllers/resque/queues/status_controller.rb
@@ -9,10 +9,14 @@ module Resque
             age(params['queue'])
           when 'size'
             size(params['queue'])
+          when 'failures_count'
+            Resque.queues_info.failures_count_for_queue(params['queue'])
           when 'threshold_size'
             Resque.queues_info.threshold_size(params.fetch('queue'))
           when 'threshold_age'
             Resque.queues_info.threshold_age(params.fetch('queue'))
+          when /^threshold_failures_per_(?<period>\w+)$/
+            Resque.queues_info.threshold_failures_count(params.fetch('queue'), $LAST_MATCH_INFO['period'])
           else
             0
           end.to_s

--- a/lib/resque/integration.rb
+++ b/lib/resque/integration.rb
@@ -63,6 +63,7 @@ module Resque
     autoload :LogsRotator, 'resque/integration/logs_rotator'
     autoload :QueuesInfo, 'resque/integration/queues_info'
     autoload :Extensions, 'resque/integration/extensions'
+    autoload :FailureBackends, 'resque/integration/failure_backends'
 
     extend ActiveSupport::Concern
 

--- a/lib/resque/integration/engine.rb
+++ b/lib/resque/integration/engine.rb
@@ -70,7 +70,10 @@ module Resque::Integration
       require 'resque/failure'
       require 'resque/failure/redis'
 
-      Resque::Failure::MultipleWithRetrySuppression.classes = [Resque::Failure::Redis]
+      Resque::Failure::MultipleWithRetrySuppression.classes = [
+        Resque::Failure::Redis,
+        Resque::Integration::FailureBackends::QueuesTotals
+      ]
 
       if Resque.config.failure_notifier.enabled?
         require 'resque_failed_job_mailer'

--- a/lib/resque/integration/failure_backends.rb
+++ b/lib/resque/integration/failure_backends.rb
@@ -1,0 +1,7 @@
+module Resque
+  module Integration
+    module FailureBackends
+      autoload :QueuesTotals, 'resque/integration/failure_backends/queues_totals'
+    end
+  end
+end

--- a/lib/resque/integration/failure_backends/queues_totals.rb
+++ b/lib/resque/integration/failure_backends/queues_totals.rb
@@ -1,0 +1,37 @@
+module Resque
+  module Integration
+    module FailureBackends
+      class QueuesTotals < ::Resque::Failure::Base
+        REDIS_COUNTER_KEY = 'resque:integration:failure_backends:queues_totals'.freeze
+        MAX_COUNTER_VALUE = 10_000_000
+
+        private_constant :REDIS_COUNTER_KEY
+
+        def save
+          current_value = Resque.redis.hincrby(REDIS_COUNTER_KEY, queue, 1)
+          Resque.redis.hset(REDIS_COUNTER_KEY, queue, 1) if current_value >= MAX_COUNTER_VALUE
+        end
+
+        def self.queues
+          Resque.redis.hkeys(REDIS_COUNTER_KEY)
+        end
+
+        def self.count(queue = nil, _class_name = nil)
+          if queue.nil?
+            Resque.redis.hvals(REDIS_COUNTER_KEY).map(&:to_i).sum
+          else
+            Resque.redis.hget(REDIS_COUNTER_KEY, queue).to_i
+          end
+        end
+
+        def self.clear(queue = nil)
+          if queue.nil?
+            Resque.redis.del(REDIS_COUNTER_KEY)
+          else
+            Resque.redis.hdel(REDIS_COUNTER_KEY, queue)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/integration/queues_info.rb
+++ b/lib/resque/integration/queues_info.rb
@@ -27,12 +27,20 @@ module Resque
         @size.overall
       end
 
+      def failures_count_for_queue(queue)
+        Resque::Integration::FailureBackends::QueuesTotals.count(queue)
+      end
+
       def threshold_size(queue)
         @config.max_size(queue)
       end
 
       def threshold_age(queue)
         @config.max_age(queue)
+      end
+
+      def threshold_failures_count(queue, period)
+        @config.max_failures_count(queue, period)
       end
 
       def data

--- a/lib/resque/integration/queues_info/config.rb
+++ b/lib/resque/integration/queues_info/config.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 module Resque
   module Integration
     class QueuesInfo
@@ -14,6 +16,10 @@ module Resque
 
         def max_size(queue)
           threshold(queue, 'max_size')
+        end
+
+        def max_failures_count(queue, period)
+          threshold(queue, "max_failures_count_per_#{period}")
         end
 
         def data
@@ -37,19 +43,18 @@ module Resque
         end
 
         def expand_config(config)
-          keys = config.keys.dup
+          expanded_config = {}
 
-          keys.each do |key|
-            v = config.delete(key)
-
+          config.keys.each do |key|
             key.split(',').each do |queue|
               queue.chomp!
               queue.strip!
-              config[queue] = v
+
+              (expanded_config[queue] ||= {}).merge!(config[key])
             end
           end
 
-          config
+          expanded_config
         end
       end
     end

--- a/spec/fixtures/resque_queues.yml
+++ b/spec/fixtures/resque_queues.yml
@@ -1,8 +1,20 @@
 defaults:
   max_age: 10
   max_size: 10
+  max_failures_count_per_5m: 5
+  max_failures_count_per_1h: 60
 
 queues:
-  first:
+  ?
+  >
+    first,
+    third
+  :
     max_age: 20
     max_size: 100
+    max_failures_count_per_5m: 15
+    max_failures_count_per_1h: 90
+
+  third:
+    max_age: 30
+    max_failures_count_per_1h: 70

--- a/spec/resque/integration/failure_backends/queues_totals_spec.rb
+++ b/spec/resque/integration/failure_backends/queues_totals_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+describe Resque::Integration::FailureBackends::QueuesTotals do
+  let(:failure) { double('UnbelievableError') }
+  let(:worker) { double('Worker') }
+  let(:payload) { double('Payload') }
+
+  describe '#save' do
+    let(:queue) { 'images' }
+    let(:backend) { described_class.new(failure, worker, queue, payload) }
+
+    before { stub_const('Resque::Integration::FailureBackends::QueuesTotals::MAX_COUNTER_VALUE', 3) }
+
+    it 'increments failures count for specified queue' do
+      expect do
+        2.times { backend.save }
+      end.to change { described_class.count(queue) }.from(0).to(2)
+    end
+
+    context 'when counter overflows' do
+      it 'resets failures count for specified queue to 1' do
+        expect do
+          3.times { backend.save }
+        end.to change { described_class.count(queue) }.from(0).to(1)
+      end
+    end
+  end
+
+  describe '.count' do
+    let(:images_queue) { 'images' }
+    let(:products_queue) { 'products' }
+    let(:images_failure_backend) { described_class.new(failure, worker, images_queue, payload) }
+    let(:products_failure_backend) { described_class.new(failure, worker, products_queue, payload) }
+
+    before do
+      2.times { images_failure_backend.save }
+      3.times { products_failure_backend.save }
+    end
+
+    context 'with specified queue' do
+      it 'returns failures count for specified queue' do
+        expect(described_class.count(images_queue)).to eq(2)
+        expect(described_class.count(products_queue)).to eq(3)
+      end
+    end
+
+    context 'with queue which has no failures' do
+      it 'returns 0' do
+        expect(described_class.count('not_failed')).to eq(0)
+      end
+    end
+
+    context 'without specified queue' do
+      it 'returns aggregated failures count from all queues' do
+        expect(described_class.count).to eq(5)
+      end
+    end
+  end
+
+  describe '.queues' do
+    context 'when has failures data' do
+      let(:images_queue) { 'images' }
+      let(:products_queue) { 'products' }
+
+      before do
+        described_class.new(failure, worker, images_queue, payload).save
+        described_class.new(failure, worker, products_queue, payload).save
+      end
+
+      it 'returns names of failed queues' do
+        expect(described_class.queues).to match_array([images_queue, products_queue])
+      end
+    end
+
+    context 'when does not have failures data' do
+      it { expect(described_class.queues).to be_empty }
+    end
+  end
+
+  describe '.clear' do
+    let(:images_queue) { 'images' }
+    let(:products_queue) { 'products' }
+
+    before do
+      described_class.new(failure, worker, images_queue, payload).save
+      described_class.new(failure, worker, products_queue, payload).save
+    end
+
+    context 'with specified queue' do
+      it 'deletes counter data for specified queue' do
+        expect { described_class.clear(products_queue) }.to change { described_class.count }.from(2).to(1)
+        expect(described_class.count(images_queue)).to eq(1)
+        expect(described_class.count(products_queue)).to eq(0)
+      end
+    end
+
+    context 'without specified queue' do
+      it 'deletes counter data for all queues' do
+        expect { described_class.clear }.to change { described_class.count }.from(2).to(0)
+        expect(described_class.count(images_queue)).to eq(0)
+        expect(described_class.count(products_queue)).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://jira.railsc.ru/browse/SG-5458 - проектирование
https://jira.railsc.ru/browse/SG-5459

@Napolskih добавил возможность указывать одну и ту же очередь как в группе, так и отдельно, как ты предлагал. Если требуется для очереди перекрыть какой-то из общих для группы параметров, нужно для этой очереди ниже по порядку в конфиге задать соответсвующие переопределения. Добавил автосброс на начальное значение при достижении `1_000_000_000` ошибок в отдельно взятой очереди.

Видимо, лучше в отдельную веточку пока, буду признателен, если кто создаст