### PR TITLE
Loose resque version to resolve dependencies

### DIFF
--- a/resque-integration.gemspec
+++ b/resque-integration.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.metadata['allowed_push_host'] = 'https://gems.railsc.ru'
 
-  gem.add_runtime_dependency 'resque', '= 1.25.2'
+  gem.add_runtime_dependency 'resque', '>= 1.25.2'
   gem.add_runtime_dependency 'railties', '>= 3.0.0'
   gem.add_runtime_dependency 'activerecord', '>= 3.0.0'
   gem.add_runtime_dependency 'actionpack', '>= 3.0.0'


### PR DESCRIPTION
```
Bundler could not find compatible versions for gem "resque":
  In Gemfile:
    apress-orders was resolved to 7.0.0, which depends on
      resque-integration (>= 1.5.0) was resolved to 1.14.0, which depends on
        resque (= 1.25.2)

    apress-orders was resolved to 7.0.0, which depends on
      resque-integration (>= 1.5.0) was resolved to 1.14.0, which depends on
        resque-scheduler (~> 4.0) was resolved to 4.2.1, which depends on
          resque (~> 1.26)
```