### PR TITLE
Limit resque-scheduler version < 4.2.1

### DIFF
--- a/resque-integration.gemspec
+++ b/resque-integration.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'resque-progress', '~> 1.0.1'
   gem.add_runtime_dependency 'resque-multi-job-forks', '~> 0.4.2'
   gem.add_runtime_dependency 'resque-failed-job-mailer', '~> 0.0.3'
-  gem.add_runtime_dependency 'resque-scheduler', '~> 4.0'
+  gem.add_runtime_dependency 'resque-scheduler', '~> 4.0', '< 4.2.1'
   gem.add_runtime_dependency 'resque-retry', '~> 1.5'
   gem.add_runtime_dependency 'god', '~> 0.13.4'
 


### PR DESCRIPTION
```
Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
Bundler could not find compatible versions for gem "resque":
  In Gemfile:
    apress-orders was resolved to 7.0.0, which depends on
      resque-integration (>= 1.5.0) was resolved to 1.14.0, which depends on
        resque (= 1.25.2)

    apress-orders was resolved to 7.0.0, which depends on
      resque-integration (>= 1.5.0) was resolved to 1.14.0, which depends on
        resque-scheduler (~> 4.0) was resolved to 4.2.1, which depends on
          resque (~> 1.26)
```