### PR TITLE
feature: обновление resque, resque-scheduler

### DIFF
--- a/dip.yml
+++ b/dip.yml
@@ -1,7 +1,7 @@
 version: '1'
 
 environment:
-  DOCKER_RUBY_VERSION: 2.2
+  DOCKER_RUBY_VERSION: '2.2'
   RUBY_IMAGE_TAG: 2.2-latest
   COMPOSE_FILE_EXT: development
   RAILS_ENV: test

--- a/lib/resque/integration/engine.rb
+++ b/lib/resque/integration/engine.rb
@@ -22,6 +22,14 @@ module Resque::Integration
       Resque.config = Resque::Integration::Configuration.new(*paths.map(&:to_s))
     end
 
+    # Читает конфиг-файл config/resque_schedule.yml
+    initializer 'resque-integration.schedule_config' do
+      if Resque.config.resque_scheduler? && Resque.config.schedule_exists?
+        config = ERB.new(File.read(Resque.config.schedule_file)).result
+        Resque.schedule = YAML.load(config)
+      end
+    end
+
     # Устанавливает для Resque соединение с Редисом,
     # данные берутся из конфига (см. выше)
     initializer 'resque-integration.redis' do

--- a/lib/resque/integration/tasks/hooks.rake
+++ b/lib/resque/integration/tasks/hooks.rake
@@ -39,11 +39,6 @@ namespace :resque do
     # Support for resque-multi-job-forks
     require 'resque-multi-job-forks' if ENV['JOBS_PER_FORK'] || ENV['MINUTES_PER_FORK']
 
-    if Resque.config.resque_scheduler? && Resque.config.schedule_exists?
-      config = ERB.new(File.read(Resque.config.schedule_file)).result
-      Resque.schedule = YAML.load(config)
-    end
-
     if Resque.config.run_at_exit_hooks? && ENV['RUN_AT_EXIT_HOOKS'].nil?
       ENV['RUN_AT_EXIT_HOOKS'] = '1'
     end

--- a/resque-integration.gemspec
+++ b/resque-integration.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.metadata['allowed_push_host'] = 'https://gems.railsc.ru'
 
-  gem.add_runtime_dependency 'resque', '= 1.25.2'
+  gem.add_runtime_dependency 'resque', '>= 1.25.2'
   gem.add_runtime_dependency 'railties', '>= 3.0.0', '< 5'
   gem.add_runtime_dependency 'activerecord', '>= 3.0.0', '< 5'
   gem.add_runtime_dependency 'actionpack', '>= 3.0.0', '< 5'
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'resque-progress', '~> 1.0.1'
   gem.add_runtime_dependency 'resque-multi-job-forks', '~> 0.4.2'
   gem.add_runtime_dependency 'resque-failed-job-mailer', '~> 0.0.3'
-  gem.add_runtime_dependency 'resque-scheduler', '~> 4.0', '< 4.2.1'
+  gem.add_runtime_dependency 'resque-scheduler', '~> 4.0'
   gem.add_runtime_dependency 'resque-retry', '~> 1.5'
   gem.add_runtime_dependency 'god', '~> 0.13.4'
 


### PR DESCRIPTION
https://jira.railsc.ru/browse/PC4-21241

resque-scheduler требует версию resque >= 1.26

в apress-application версия resque зафиксирована https://github.com/abak-press/apress-application/blob/298d29072917cb2097933775744cd397a6b34ff8/apress-application.gemspec#L28

загрузка конфига будет делаться в инитиалайзере проекта, тут подхватится https://github.com/DmitryBochkarev/resque-integration/blob/7a97c8231fcef3ed658f8da6f9d75b6f57817fad/lib/resque/integration/tasks/hooks.rake#L11