### PR TITLE
 fix: keep meta_id on_failure_retry callback if Resque::DirtyExit occurred

### DIFF
--- a/lib/resque/integration/unique.rb
+++ b/lib/resque/integration/unique.rb
@@ -119,6 +119,13 @@ module Resque
         !meta.working?
       end
 
+      def on_failure_retry(exception, *args)
+        # Keep meta_id if kill -9 (or ABRT)
+        @meta_id = args.first if exception.is_a?(::Resque::DirtyExit)
+
+        super
+      end
+
       # Before enqueue acquire a lock
       #
       # Returns boolean

--- a/spec/resque/integration/unique_spec.rb
+++ b/spec/resque/integration/unique_spec.rb
@@ -125,3 +125,39 @@ describe Resque::Integration::Unique, '#dequeue' do
     worker.join
   end
 end
+
+describe Resque::Integration::Unique, '#on_failure_retry' do
+  class JobUniqueWithRetry
+    include Resque::Integration
+    extend Resque::Plugins::Retry
+
+    @retry_limit = 2
+    @retry_delay = 1
+    @retry_exceptions = [IOError]
+
+    unique do |foo_var, params|
+      params[:foo]
+    end
+
+    queue :default
+
+    def self.execute(foo_var, params)
+      sleep 0.2
+      Resque.logger.info 'Hello, world'
+    end
+  end
+
+  let(:worker) { Resque::Worker.new(:default) }
+  let(:job) { Resque::Job.new(:default, 'class' => 'JobUniqueWithRetry', 'args' => ['abcd', 1, {foo: 'bar'}]) }
+
+  before do
+    worker.working_on(job)
+  end
+
+  it do
+    expect { worker.unregister_worker }.not_to raise_error
+
+    expect(Resque::Failure.count).to eq 1
+    expect(Resque::Failure.all['exception']).to eq 'Resque::DirtyExit'
+  end
+end


### PR DESCRIPTION

https://jira.railsc.ru/browse/BPC-10431
https://jira.railsc.ru/browse/PC4-21678