### PR TITLE
fix: use current rake tasks

### DIFF
--- a/lib/resque/integration/god.erb
+++ b/lib/resque/integration/god.erb
@@ -13,7 +13,7 @@ God.terminate_timeout = <%= terminate_timeout.to_i %>
       w.group = 'resque'
       w.interval = 30.seconds
       w.env = <%= Resque.config.env.merge(worker.env).merge(:RAILS_ENV => ::Rails.env, :BUNDLE_GEMFILE => "#{root}/Gemfile").stringify_keys! %>
-      w.start = "#{bundle} exec rake -f #{rails_root}/Rakefile resque:work"
+      w.start = "#{bundle} exec rake resque:work"
       w.log = '<%= log_file %>'
       w.stop_signal = 'QUIT'
 
@@ -61,7 +61,7 @@ God.terminate_timeout = <%= terminate_timeout.to_i %>
     w.group = 'resque'
     w.interval = 30.seconds
     w.env = <%= Resque.config.env.merge(:RAILS_ENV => ::Rails.env, :BUNDLE_GEMFILE => "#{root}/Gemfile").stringify_keys! %>
-    w.start = "#{bundle} exec rake -f #{rails_root}/Rakefile environment resque:scheduler"
+    w.start = "#{bundle} exec rake environment resque:scheduler"
     w.log = '<%= log_file %>'
     w.stop_signal = 'QUIT'
     w.stop_timeout = 60.seconds


### PR DESCRIPTION
> Artem Napolskih, [16.04.18 09:20]
> 
> я поразбирался с рескью, накопал кое-что.
> 
> вообщем проблема происходит из-за того что этот код
> https://github.com/abak-press/pulscen/blob/develop/config/application.rb
> выполняется два раза в одном процессе.
> причем происходит это и в 3 и в 4 рельсах.
> происходит только на тестовых.
> 
> почему ? потому что руби определяет рекваирил ли файл, по полному пути.
> рейк запускается так
> w.start = "#{bundle} exec rake -f #{rails_root}/Rakefile resque:work"
> 
> заметь, что передается полный путь до рейк файла (зачем-то, не понятно зачем, ведь все равно он возьмет из текущей рут папки)
> 
> в результате сначала рекваирится все по пути 
> /home/pc/current/
> потом видимо после установки текущей папки в рельсах, идет загрузка всего того же самого уже из 
> /home/pc/sites/pulscen/releases/
> 
> на ноже год есть, но там не указан рут дир и берется текущий и всехорошо - код выполняется один раз, на тестовых если убрать тоже ок.
> 
> у меня есть разные возможности для фикса
> 1. я просто в аппликейшене первый раз ставлю флаг и потом проверяю его и не выполнят код дважды, это работает, рескью норм работает.
> 
> 2. я правлю год-конфиг и убераю путь до рейк файла
> w.start = "#{bundle} exec rake resque:work" 
> тоже все работает, код даже не пытается два раза выполняться, потому что не рекваирится.
> 
> я не понимаю зачем указывать полный путь и я бы его убрал из конфига года.
> 
> вот лог запуска с дублированием:
> 
>  [00:23:08 2018-04-16] 22209: Starting worker main
>  [00:23:08 2018-04-16] 22209: Running before_first_fork hooks
> 
> ««<------- тут первый раз аппликейшн выполняется, смотри пути
> ["__________________________", 2018-04-16 00:22:10 +0500, 47014146423120, true, true, 22216, ["/home/pc/current/config/application.rb:35:in <module:Core>'", "/home/pc/current/config/application.rb:34:in <top (required)>'", "/home/pc/current/Rakefile:7:in require'", "/home/pc/current/Rakefile:7:in <top (required)>'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/rake_module.rb:28:in load'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/rake_module.rb:28:in `load_rakefile'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:687:in `raw_load_rakefile'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:94:in `block in load_rakefile'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:176:in `standard_exception_handling'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:93:in `load_rakefile'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:77:in `block in run'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:176:in `standard_exception_handling'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:75:in `run'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/bin/rake:33:in <top (required)>'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/bin/rake:22:in load'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/bin/rake:22:in <main>'"], "Core::Application"]
> 
> Artem Napolskih, [16.04.18 09:20]
> ««<------- тут второй раз аппликейшн выполняется, пути уже другие
> ["________________________ 0", 2018-04-16 00:22:11 +0500, 47014146423120, true, true, 22216, ["/home/pc/sites/pulscen/releases/20180413064209/config/application.rb:35:in <module:Core>'", "/home/pc/sites/pulscen/releases/20180413064209/config/application.rb:34:in <top (required)>'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:229:in require'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:229:in `block in require'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:214:in `load_dependency'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:229:in `require'", "/home/pc/sites/pulscen/releases/20180413064209/config/environment.rb:3:in <top (required)>'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:229:in require'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:229:in `block in require'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:214:in `load_dependency'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:229:in `require'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/railties-4.0.13/lib/rails/application.rb:189:in `require_environment!'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/railties-4.0.13/lib/rails/application.rb:260:in `block in run_tasks_blocks'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/task.rb:240:in `call'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/task.rb:240:in `block in execute'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/task.rb:235:in `each'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/task.rb:235:in `execute'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/task.rb:179:in `block in invoke_with_call_chain'", "/usr/lib64/ruby/2.2.0/monitor.rb:211:in `mon_synchronize'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/task.rb:172:in `invoke_with_call_chain'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/task.rb:165:in `invoke'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:150:in `invoke_task'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:106:in `block (2 levels) in top_level'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:106:in `each'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:106:in `block in top_level'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:115:in `run_with_threads'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:100:in `top_level'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:78:in `block in run'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:176:in `standard_exception_handling'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/lib/rake/application.rb:75:in `run'", "/home/pc/static/pulscen/local/bundle/ruby/2.2.0/gems/rake-10.3.2/bin/rake:33:in <top (required)>'"], "Core::Application"]
> 
> ** [00:30:01 2018-04-16] 22209: got: (Job{company_statistics_daily} | RakeTaskJob | [{"task"=>"company_statistics:daily", "log"=>"log/statistics/companies/daily.log"}])
> 
> можно еще попробовать рейк гем обновить, там вышла пара версий. но явный косяк с путями, симилинками.
> 

![image](https://user-images.githubusercontent.com/1475358/38792490-a5580f02-4166-11e8-881d-4dd1ead9512b.png)

> 
> Михаил Меркушин, [16.04.18 10:01]
> Я помню такую историю, что мы бороилсь с тем, чтобы god не держал ссылки на релизные папки, так как они удаляются, а god никогда не перезапускается. Скорее всего это с этим связано.
> 
> Но вот сейчас смотрю
> pc@h5124-pc-job4.lance ~/current $ lsof | grep 17187 | grep releases
> Ссылки все равно есть. Это не очень хорошо конечно.
> 
> То, что руби два раза файлы рекварит, это все продолжение той истории, которую вроде Бочкарев правил в деплое, когда по симлинки и прямом у пути на один и тот же файл Руби два раза рекварит.
> 
> Я если честно хз что с этим всем делать. Давай попробуем уберем -f, посмотрим какие ссылки будут оставаться
> 
> Artem Napolskih, [16.04.18 10:56]
> 
> у меня два варианта, или поправить гем? и сделать что бы другой конфиг для года генерился.
> или убрать просто из конфига рескью рут дир и тогда все само будет.
> 
> тогда рут будет тем же те из текущей папки
>       def root
>         self['resque.root'] || ::Rails.root.to_s
>       end
> 
> Михаил Меркушин, [16.04.18 10:57]
> Жопой чую - уберешь рут дир - начнутся новые веселые проблемы