### PR TITLE
feature: redis >= 4.2 support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,24 +33,6 @@ spec_step_common: &spec_step_common
     - dip rspec
 
 steps:
-  - name: Tests Ruby 2.2
-    environment:
-      COMPOSE_FILE_EXT: drone
-      DOCKER_RUBY_VERSION: 2.2
-      RUBY_IMAGE_TAG: 2.2-latest
-      REDIS_IMAGE_TAG: 4-alpine
-      RAILS_ENV: test
-    <<: *spec_step_common
-
-  - name: Tests Ruby 2.3
-    environment:
-      COMPOSE_FILE_EXT: drone
-      DOCKER_RUBY_VERSION: 2.3
-      RUBY_IMAGE_TAG: 2.3-latest
-      REDIS_IMAGE_TAG: 4-alpine
-      RAILS_ENV: test
-    <<: *spec_step_common
-
   - name: Tests Ruby 2.4
     environment:
       COMPOSE_FILE_EXT: drone

--- a/Appraisals
+++ b/Appraisals
@@ -1,17 +1,3 @@
-if RUBY_VERSION < '2.4'
-  appraise 'rails3.2' do
-    gem 'rails', '~> 3.2.0'
-  end
-
-  appraise 'rails4.0' do
-    gem 'rails', '~> 4.0.13'
-  end
-
-  appraise 'rails4.1' do
-    gem 'rails', '~> 4.1.16'
-  end
-end
-
 appraise 'rails4.2' do
   gem 'rails', '~> 4.2.9'
 end
@@ -26,5 +12,4 @@ end
 
 appraise 'rails5.2' do
   gem 'rails', '~> 5.2.0', '< 5.2.4.1'
-  gem 'mimemagic', '<= 0.3.9' if RUBY_VERSION < '2.3'
 end

--- a/dip.yml
+++ b/dip.yml
@@ -1,8 +1,8 @@
 version: '1'
 
 environment:
-  DOCKER_RUBY_VERSION: 2.3
-  RUBY_IMAGE_TAG: 2.3-latest
+  DOCKER_RUBY_VERSION: 2.4
+  RUBY_IMAGE_TAG: 2.4-latest
   REDIS_IMAGE_TAG: 4-alpine
   COMPOSE_FILE_EXT: development
   RAILS_ENV: test
@@ -40,6 +40,5 @@ interaction:
 provision:
   - docker volume create --name bundler_data
   - dip bundle config --local https://gems.railsc.ru/ ${APRESS_GEMS_CREDENTIALS}
-  - dip clean
   - dip bundle install
   - dip appraisal install

--- a/lib/resque/integration/tasks/hooks.rake
+++ b/lib/resque/integration/tasks/hooks.rake
@@ -37,7 +37,7 @@ namespace :resque do
     end
 
     Resque.after_fork do |job|
-      $0 = "resque-#{Resque::Version}: Processing #{job.queue}/#{job.payload['class']} since #{Time.now.to_s(:db)}"
+      $0 = "resque-#{Resque::Version}: Processing #{job.queue}/#{job.payload['class']} since #{Time.now.to_s}"
 
       ActiveRecord::Base.establish_connection
 

--- a/lib/resque/integration/unique.rb
+++ b/lib/resque/integration/unique.rb
@@ -166,7 +166,7 @@ module Resque
 
       # Returns true if resque job is in locked state
       def locked?(*args)
-        ::Resque.redis.exists(lock_id(*args))
+        ::Resque.redis.exists?(lock_id(*args))
       end
 
       # Dequeue unique job

--- a/resque-integration.gemspec
+++ b/resque-integration.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'resque', '>= 1.25.2'
   gem.add_runtime_dependency 'rails', '>= 3.0.0'
+  gem.add_runtime_dependency 'redis', '>= 4.2.0'
   gem.add_runtime_dependency 'resque-meta', '>= 2.0.0'
   gem.add_runtime_dependency 'resque-progress', '~> 1.0.1'
   gem.add_runtime_dependency 'resque-multi-job-forks', '~> 0.4.2'


### PR DESCRIPTION
Начиная с 4.2 изменилось поведение метода `Redis#exists` - возвращает количество существующих ключей, а не true/false.

Да, есть опция `exists_returns_integer`, но это временно